### PR TITLE
ref(translate): add Render and Register for Libraries to use instead …

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -25,6 +25,7 @@
     "dupl",
     "Elts",
     "errcheck",
+    "Errorf",
     "exportloopref",
     "extendio",
     "faydeaudeau",

--- a/README.md
+++ b/README.md
@@ -57,3 +57,201 @@ To maintain localisation of the application, the user must take care to implemen
 + define template struct (__xxxTemplData__) in __src/i18n/messages.go__ and corresponding __Message()__ method. All messages are defined here in the same location, simplifying the message extraction process as all extractable strings occur at the same place. Please see [go-i18n](https://github.com/nicksnyder/go-i18n) for all translation/pluralisation options and other regional sensitive content.
 
 For more detailed workflow instructions relating to i18n, please see [i18n README](./resources/doc/i18n-README.md). For details on how defining translate-able content can be achieved consistently using code generation, see [Lingo](./resources/doc/LINGO.md)
+
+## 🚀 Coding Guidelines
+
+### Using li18ngo in Your Application
+
+`li18ngo` wraps `go-i18n` and adds a localisation lifecycle on top of it. The
+library distinguishes between two phases: __bootstrap__ (registering languages
+and activating a language) and __runtime__ (translating messages via `Text`).
+You must complete the bootstrap phase before making any `Text` calls, or the
+library will not behave correctly.
+
+---
+
+### Bootstrap Phase
+
+Before your application renders any localised string, call `Use` to activate
+the library and register your supported languages:
+
+```go
+err := li18ngo.Use(func(o *li18ngo.UseOptions) {
+    o.Tag = language.BritishEnglish
+    o.From = li18ngo.LoadFrom{
+        Path: "path/to/translations",
+        Sources: li18ngo.TranslationFiles{
+            li18ngo.Li18ngoSourceID: li18ngo.TranslationSource{
+                Name: "li18ngo",
+            },
+            <YourPackage>.SourceID: li18ngo.TranslationSource{
+                Name: "<your-app>",
+            },
+        },
+    }
+})
+```
+
+`Use` must be called exactly once per process lifetime, typically at the very
+start of your `main` function or, for CLI applications built on Cobra/Mamba,
+inside the bootstrap function that runs before any command executes.
+
+If you ship a library that builds on `li18ngo`, call `Register` instead of
+`Use` - `Register` is the per-library entry point that tells `li18ngo` about
+your translation sources so that a host application can load them:
+
+```go
+func init() {
+    li18ngo.Register(func(o *li18ngo.RegisterOptions) {
+        o.SourceID = SourceID
+        o.DefaultFS = &translationsFS
+    })
+}
+```
+
+The host application then includes your `SourceID` in its `Use` call, as shown
+above.
+
+😮‍💨 It needs to be acknowledged that building i18n compliant applications and libraries
+can be quite onerous and a real pain in the you know whats. For this reason, it is
+not mandatory to participate in the i18n infrastructure, just because one of your
+dependencies does. i18n is not mandatory, but invoking Use/Register is. If you do not want
+to participate in i18n, then just invoke these functions without passing in a registration
+function, ie you can just do this:
+
+for applications:
+
+```go
+  li18ngo.Use()
+```
+
+for libraries:
+
+```go
+  li18ngo.Register()
+```
+
+When no registration function is passed into Use/Register, then `Text` will just
+return the default text as created by the library/application author; ie the text
+you see in the `Other` field of the `TemplData` struct's `Message` method.
+
+---
+
+### Translating Messages at Runtime
+
+Once bootstrap is complete, translate a message by constructing its template
+data struct and passing it to `li18ngo.Text`:
+
+```go
+msg := li18ngo.Text(MyMessageTemplData{})
+```
+
+For messages that carry dynamic content, populate the exported fields of the
+template data struct before passing it:
+
+```go
+msg := li18ngo.Text(FileNotFoundTemplData{
+    Name: path,
+})
+```
+
+`Text` returns a plain `string`. It never returns an error - if something goes
+wrong (missing translation, uninitialised library), it falls back gracefully,
+so you do not need to check a return value beyond the string itself.
+
+When you define messages with dynamic content, then a helper function is provided
+to relieve the author from knowing the full way to compose the appropriate structs,
+eg:
+
+```go
+  msg := li18ngo.Text(locale.NewRootCmdConfigFileUsageTemplData(
+    viper.ConfigFileUsed()),
+  )
+```
+
+---
+
+### Defining Messages
+
+All user-facing strings are represented as template data structs typically in the
+`locale` package (but this can be overridden by using the `--locale` flag on `lingo`). There are distinct message patterns, summarised below. (For the full enumeration definition, see [UnderlyingType](./locale/enums/underlying-type-en.go))
+
+| Type | Emoji | Enum(UnderlyingType) | When to use |
+| --- | --- | --- | --- |
+| Cobra static | 🧊 | StaticCobra | Plain informational string, no variable content |
+| Cobra dynamic | 🧊 | DynamicCobra | Informational string with one or more variable tokens |
+| General static | 📨 | StaticGeneral | Plain informational string, no variable content |
+| General dynamic | 📨 | DynamicGeneral | Informational string with one or more variable tokens |
+| Static error | ❌ | StaticError | Fixed error message, no variable content |
+| Static sentinel error | ❌ | SentinelError | Fixed error message; produces an exported sentinel `var Err...`. Designed to be wrapped |
+| Static error (wrapper) | ❌ | StaticErrorWrapper | Error with no variable context that wraps an underlying error, wrapped error does nopt appear in translated output |
+| Static error (wrapper) | ❌ | StaticErrorWrapperMsg | Error with no variable context that wraps an underlying error, wrapped error appears in translated output |
+| Dynamic error (no wrap) | ❌ | DynamicError | Error carrying variable context, does not wrap another error |
+| Dynamic error (wrapper) | ❌ | DynamicErrorWrapper | Error with variable context that wraps an underlying error |
+
+Message IDs follow a strict convention:
+
+| Message kind | ID format |
+| --- | --- |
+| Non-error | `kebab-slug` |
+| Static error | `kebab-slug.static-error` |
+| Dynamic error | `kebab-slug.dynamic-error` |
+
+Never omit the `.static-error` / `.dynamic-error` suffix from error message
+IDs and never add those suffixes to non-error messages. This is just a suggested convention; the author is free to use whatever scheme they wish.
+
+---
+
+### Code Generation
+
+The `lingo` code generation tool manages the `messages-general-auto.go`,
+`messages-errors-auto.go` and `messages-cobra-auto.go` description files automatically. You
+should not hand-edit those generated files. The source of truth is
+the `Underliers` map - add or modify message
+descriptors there and re-run `lingo` to regenerate the output files. Full
+documentation for [Lingo](./resources/doc/LINGO.md) is covered separately.
+
+---
+
+### Translation Files
+
+Translation files are JSON and follow the `go-i18n` format. The active
+language is selected by the `Tag` passed to `Use`. If no translation file
+exists for the requested language, `go-i18n` falls back to the default
+language (typically `en-GB`, depending on how your `Use` call is
+configured).
+
+Place translation files in a directory that is either embedded via `go:embed`
+or readable from disk. Pass the corresponding `fs.FS` or path to `Use` via
+`LoadFrom`.
+
+---
+
+### Error Handling Conventions
+
+Static errors expose a package-level sentinel variable (`Err<Name>`) that
+callers can match using the standard `errors.Is` / `errors.As` functions - no
+generated helper wrappers are provided or needed:
+
+```go
+if errors.Is(err, locale.ErrFilterMissingType) {
+    // handle it
+}
+```
+
+Dynamic errors that wrap an underlying error implement `Unwrap`, so
+`errors.Is` and `errors.As` chains work correctly without any extra
+boilerplate.
+
+---
+
+### Troubleshooting
+
+| Symptom | Likely cause | Fix |
+| --- | --- | --- |
+| All messages return the fallback / English string despite setting a language | `Use` was not called before the first `Text` call | Move your `Use` call earlier in bootstrap, before any command or handler executes |
+| `Text` returns an empty string or panics | The message ID in the template data struct does not match the key in the translation JSON file | Check that `lingo` has been re-run after any change to `Underliers`, and that the translation file has been updated |
+| A library's messages are not translated | The library's `SourceID` is missing from the `Sources` map in `Use` | Add the library's `SourceID` and `TranslationSource` to the host application's `Use` call |
+| `Register` has no effect | `Register` was called after `Use` | `Register` must be called before `Use` - put it in a library `init` function |
+| Sentinel error does not match via `errors.Is` | Caller wrapped the sentinel in a new error without preserving the chain | Use `fmt.Errorf("...: %w", locale.ErrFoo)` to wrap, not `fmt.Errorf("...: %v", ...)` |
+| Generated files contain stale or missing messages | `lingo` has not been run after editing `Underliers` | Run `lingo` and commit the regenerated files |

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -232,3 +232,13 @@ tasks:
         -sourceLanguage "en-US"
         -outdir ./i18n/temp
         ./locale/out/translate.en-US.json ./i18n/deploy/active.en-US.json
+
+  # === vscode ===============================================
+
+  # use this if you notice that vscode is starting to act strangely, such as not picking
+  # up changes to files, or not showing the correct file structure. This will reset
+  # the workspace storage for vscode, which can sometimes become corrupted and cause issues.
+  reset-vscode:
+    cmds:
+      - rm -rf ~/Library/Application\ Support/Code/User/workspaceStorage
+

--- a/internal/translate/localisable-error.go
+++ b/internal/translate/localisable-error.go
@@ -5,6 +5,8 @@ type LocalisableError struct {
 	Data Localisable
 }
 
+// Error uses Describe rather than Text so that it is safe to use in library
+// code before the host application has called Use.
 func (le LocalisableError) Error() string {
-	return Text(le.Data)
+	return Render(le.Data)
 }

--- a/internal/translate/localisable-error_test.go
+++ b/internal/translate/localisable-error_test.go
@@ -1,0 +1,69 @@
+package translate_test
+
+import (
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	"github.com/pkg/errors"
+	"github.com/snivilised/li18ngo"
+	"github.com/snivilised/li18ngo/internal/translate"
+	"github.com/snivilised/li18ngo/locale"
+)
+
+var _ = Describe("LocalisableError", func() {
+	BeforeEach(func() {
+		translate.ResetTx()
+	})
+
+	Context("Error()", func() {
+		When("Use has not been called", func() {
+			It("🧪 should: return the canonical Other string rather than panicking", func() {
+				// This is the critical regression guard: LocalisableError.Error()
+				// must be safe to call in library code at any point in the
+				// host application lifecycle.
+				err := li18ngo.LocalisableError{
+					Data: localisableErrorFixtureTemplData{},
+				}
+
+				Expect(err.Error()).To(Equal("something went wrong in the fixture"))
+			})
+		})
+
+		When("Use has been called", func() {
+			It("🧪 should: return the localised string via the active translator", func() {
+				Expect(li18ngo.Use()).To(Succeed())
+
+				err := li18ngo.LocalisableError{
+					Data: locale.LocalisationTemplData{},
+				}
+
+				Expect(err.Error()).To(Equal("localisation"))
+			})
+		})
+
+		When("the error is compared using errors.Is", func() {
+			It("🧪 should: still satisfy sentinel error matching without Use", func() {
+				// Wrapping errors must remain comparable even when tx is nil.
+				// This guards against any change to Error() accidentally
+				// breaking errors.Is semantics.
+				type wrappingError struct {
+					li18ngo.LocalisableError
+					Wrapped error
+				}
+
+				sentinel := errors.New("sentinel")
+				wrapped := wrappingError{
+					LocalisableError: li18ngo.LocalisableError{
+						Data: localisableErrorFixtureTemplData{},
+					},
+					Wrapped: sentinel,
+				}
+
+				// errors.Is walks the chain; the wrapping struct needs Unwrap.
+				// This test verifies the Error() fallback does not interfere
+				// with the error identity chain.
+				Expect(errors.Is(wrapped.Wrapped, sentinel)).To(BeTrue())
+			})
+		})
+	})
+})

--- a/internal/translate/register_test.go
+++ b/internal/translate/register_test.go
@@ -1,0 +1,60 @@
+package translate_test
+
+import (
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	"github.com/snivilised/li18ngo"
+	"github.com/snivilised/li18ngo/internal/translate"
+	"github.com/snivilised/li18ngo/locale"
+)
+
+var _ = Describe("Register", func() {
+	BeforeEach(func() {
+		translate.ResetTx()
+	})
+
+	Context("library bootstrap", func() {
+		When("Register is called without options", func() {
+			It("🧪 should: succeed and activate the translator", func() {
+				// Register has the same mechanics as Use; a library calling
+				// Register before the host calls Use should not cause a panic
+				// when Text or Describe is subsequently invoked.
+				Expect(li18ngo.Register()).To(Succeed())
+			})
+		})
+
+		When("Register is called before Use", func() {
+			It("🧪 should: allow Describe to return localised text", func() {
+				Expect(li18ngo.Register()).To(Succeed())
+
+				result := li18ngo.Render(locale.LocalisationTemplData{})
+				Expect(result).To(Equal("localisation"))
+			})
+		})
+
+		When("Register is called before Use", func() {
+			It("🧪 should: not cause Text to panic when host later calls Use", func() {
+				// Simulates: library calls Register at init time, host calls
+				// Use at startup - the negotiation path should merge sources.
+				Expect(li18ngo.Register()).To(Succeed())
+				Expect(li18ngo.Use()).To(Succeed())
+
+				result := li18ngo.Text(locale.LocalisationTemplData{})
+				Expect(result).To(Equal("localisation"))
+			})
+		})
+
+		When("Use is called before Register", func() {
+			It("🧪 should: not cause Text to panic when library later calls Register", func() {
+				// Simulates: host bootstraps first, library registers late -
+				// the more common ordering in practice.
+				Expect(li18ngo.Use()).To(Succeed())
+				Expect(li18ngo.Register()).To(Succeed())
+
+				result := li18ngo.Text(locale.LocalisationTemplData{})
+				Expect(result).To(Equal("localisation"))
+			})
+		})
+	})
+})

--- a/internal/translate/render_test.go
+++ b/internal/translate/render_test.go
@@ -1,0 +1,38 @@
+package translate_test
+
+import (
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	"github.com/snivilised/li18ngo"
+	"github.com/snivilised/li18ngo/internal/translate"
+	"github.com/snivilised/li18ngo/locale"
+)
+
+var _ = Describe("Render", func() {
+	BeforeEach(func() {
+		translate.ResetTx()
+	})
+
+	Context("before Use has been called", func() {
+		When("tx is nil", func() {
+			It("🧪 should: return the canonical Other string without panicking", func() {
+				// This is the core library-safety guarantee: Render must never
+				// panic regardless of initialisation state.
+				result := li18ngo.Render(localisableErrorFixtureTemplData{})
+				Expect(result).To(Equal("something went wrong in the fixture"))
+			})
+		})
+	})
+
+	Context("after Use has been called", func() {
+		When("a native package message is described", func() {
+			It("🧪 should: return the localised string via the active translator", func() {
+				Expect(li18ngo.Use()).To(Succeed())
+
+				result := li18ngo.Render(locale.LocalisationTemplData{})
+				Expect(result).To(Equal("localisation"))
+			})
+		})
+	})
+})

--- a/internal/translate/text_test.go
+++ b/internal/translate/text_test.go
@@ -7,6 +7,7 @@ import (
 	. "github.com/onsi/gomega"
 
 	"github.com/snivilised/li18ngo"
+	"github.com/snivilised/li18ngo/internal/translate"
 	"github.com/snivilised/li18ngo/locale"
 )
 
@@ -56,6 +57,47 @@ var _ = Describe("Text", func() {
 						"should use localizer that was created on the fly",
 					)
 				})
+			})
+		})
+	})
+})
+
+var _ = Describe("Text", func() {
+	BeforeEach(func() {
+		translate.ResetTx()
+	})
+
+	Context("after Register but before Use", func() {
+		When("Text is called by application code", func() {
+			It("🧪 should: not panic because Register activates the translator", func() {
+				// Register activates tx just as Use does; application code
+				// calling Text after a library has called Register should
+				// therefore not encounter a panic.
+				Expect(li18ngo.Register()).To(Succeed())
+
+				Expect(func() {
+					_ = li18ngo.Text(locale.LocalisationTemplData{})
+				}).NotTo(Panic())
+			})
+		})
+	})
+
+	Context("without Use or Register", func() {
+		When("Text is called by application code", func() {
+			It("🧪 should: still panic with ErrSafePanicWarning", func() {
+				// Regression guard: the existing panic contract for Text must
+				// be preserved. Describe's nil-safety must not weaken Text.
+				defer func() {
+					if r := recover(); r != nil {
+						if err, ok := r.(error); ok && errors.Is(err, li18ngo.ErrSafePanicWarning) {
+							return
+						}
+					}
+					Fail("safe panic warning has not occurred")
+				}()
+
+				_ = li18ngo.Text(locale.InternationalisationTemplData{})
+				Fail("expected panic to occur")
 			})
 		})
 	})

--- a/internal/translate/translate-defs.go
+++ b/internal/translate/translate-defs.go
@@ -19,8 +19,9 @@ const (
 )
 
 var (
-	// ErrSafePanicWarning the error emitted via a panic if the client has not called
-	// Use before using any functionality in this package.
+	// ErrSafePanicWarning is emitted via panic if application code calls Text
+	// before Use has been invoked. Library code should use Describe instead,
+	// which falls back gracefully to the canonical message string.
 	ErrSafePanicWarning = errors.New("please ensure li18ngo.Use is invoked")
 )
 

--- a/internal/translate/translate-suite_test.go
+++ b/internal/translate/translate-suite_test.go
@@ -6,6 +6,7 @@ import (
 	"github.com/nicksnyder/go-i18n/v2/i18n"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
+	"github.com/snivilised/li18ngo/locale"
 )
 
 func TestTranslate(t *testing.T) {
@@ -40,5 +41,26 @@ func (td AtTheGatesOfSilentMemoryTemplData) Message() *i18n.Message {
 		ID:          "at-the-gates-of-silent-memory.message",
 		Description: "at the gates of silent memory",
 		Other:       "at the gates of silent memory",
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Test fixtures
+//
+// Two minimal Localisable implementations used only in this file, keeping
+// each describe block self-contained and avoiding cross-file fixture coupling.
+// ---------------------------------------------------------------------------
+
+// localisableErrorFixtureTemplData is a static non-error message used to
+// exercise LocalisableError.Error() in isolation.
+type localisableErrorFixtureTemplData struct {
+	locale.Li18ngoTemplData
+}
+
+func (td localisableErrorFixtureTemplData) Message() *i18n.Message {
+	return &i18n.Message{
+		ID:          "localisable-error-fixture",
+		Description: "fixture message for LocalisableError tests",
+		Other:       "something went wrong in the fixture",
 	}
 }

--- a/internal/translate/translator.go
+++ b/internal/translate/translator.go
@@ -79,6 +79,28 @@ func Text(data Localisable) string {
 	panic(ErrSafePanicWarning)
 }
 
+// Render is the library-tier localisation function. It is safe to call
+// even if Use has not been called by the host application - it falls back
+// to the canonical English string defined in data.Message().Other. Library
+// authors should use Render (via LocalisableError) rather than Text.
+func Render(data Localisable) string {
+	if tx != nil {
+		return tx.Localise(data)
+	}
+
+	return data.Message().Other
+}
+
+// Register is the library-tier equivalent of Use. A library that depends on
+// li18ngo should call Register to add its translation sources to the active
+// translator. Libraries must never call Use - that is an application
+// bootstrap concern.
+func Register(options ...UseOptionFn) error {
+	// Same mechanics as Use; the distinction is semantic and enforced by
+	// convention. A future lint rule can enforce this boundary.
+	return Use(options...)
+}
+
 func containsLanguage(languages SupportedLanguages, tag language.Tag) bool {
 	return lo.ContainsBy(languages, func(t language.Tag) bool {
 		return t == tag

--- a/li18ngo-api.go
+++ b/li18ngo-api.go
@@ -11,8 +11,9 @@ var (
 	// DefaultLanguage represents the default language of this module
 	DefaultLanguage = translate.DefaultLanguage
 
-	// ErrSafePanicWarning is the error raised as a panic if the client
-	// has accidentally not called Use before working with li18ngo.
+	// ErrSafePanicWarning is emitted via panic if application code calls Text
+	// before Use has been invoked. Library code should use Describe instead,
+	// which falls back gracefully to the canonical message string.
 	ErrSafePanicWarning = translate.ErrSafePanicWarning
 
 	// Li18ngoSourceID the id that represents this module. If a client want
@@ -30,6 +31,12 @@ var (
 	// Not threadsafe.
 	Text = translate.Text
 
+	// Render is the library-tier localisation function. It is safe to call
+	// even if Use has not been called by the host application - it falls back
+	// to the canonical English string defined in data.Message().Other. Library
+	// authors should use Render (via LocalisableError) rather than Text.
+	Render = translate.Render
+
 	// Use, must be called before any string data can be translated.
 	// If requesting the default language, then only the language Tag
 	// needs to be provided. If the requested language is not the default
@@ -41,6 +48,12 @@ var (
 	// used. The client MUST call Use before using any functionality in
 	// this package.
 	Use = translate.Use
+
+	// Register is the library-tier equivalent of Use. A library that depends on
+	// li18ngo should call Register to add its translation sources to the active
+	// translator. Libraries must never call Use - that is an application
+	// bootstrap concern.
+	Register = translate.Register
 )
 
 type (

--- a/locale/enums/underlying-type.en.go
+++ b/locale/enums/underlying-type.en.go
@@ -7,66 +7,7 @@ type UnderlyingType uint
 
 // =============================================================================
 //
-// # UnderlyingType guide
-//
-// Each entry in the Underliers map must set a TypeName field. The type controls
-// which code is generated for that message. The rules are:
-//
-//	UnderlyingTypeCobraStatic
-//	  A short description string for a Cobra command or flag.
-//	  Fields must be empty. No constructor generated.
-//
-//	UnderlyingTypeCobraDynamic
-//	  A long description string for a Cobra command or flag.
-//	  Fields must be non-empty. NewXxxTemplData constructor generated.
-//	  Every {{.Token}} in Other must have a matching Fields entry and
-//	  vice versa.
-//
-//	UnderlyingTypeGeneralStatic
-//	  A non-error user-facing message with no variable content.
-//	  Fields must be empty. No constructor generated.
-//
-//	UnderlyingTypeGeneralDynamic
-//	  A non-error user-facing message with variable content.
-//	  Fields must be non-empty. NewXxxTemplData constructor generated.
-//	  Every {{.Token}} in Other must have a matching Fields entry and
-//	  vice versa.
-//
-//	UnderlyingTypeErrorStatic
-//	  An error with no variable content.
-//	  Fields must be empty.
-//	  Generates: XxxErrorTemplData, XxxError, ErrXxx sentinel.
-//
-//	UnderlyingTypeErrorCore
-//	  A static sentinel error designed to be wrapped by outer errors.
-//	  Fields must be empty.
-//	  Generates: XxxErrorTemplData, XxxError, ErrXxx (exported sentinel).
-//	  Callers use errors.Is(err, locale.ErrXxx) directly.
-//
-//	UnderlyingTypeErrorStaticWrapper
-//	  A static error that wraps another error.
-//	  Fields must be empty (Wrapped is implicit, not declared in Fields).
-//	  Generates: XxxErrorTemplData, XxxError{Wrapped error},
-//	             NewXxxError(wrapped error), AsXxxError helper,
-//	             Error() string, Unwrap() error.
-//
-//	UnderlyingTypeErrorDynamic
-//	  An error with variable content but no wrapping.
-//	  Fields must be non-empty. No Wrapped field permitted in Fields.
-//	  Generates: XxxTemplData, XxxError, NewXxxError(fields...),
-//	             AsXxxError helper.
-//
-//	UnderlyingTypeErrorDynamicWrapper
-//	  An error with variable content that also wraps another error.
-//	  Fields must be non-empty and must contain exactly one entry with
-//	  GoType "error" and Name "Wrapped". The Wrapped field may appear as
-//	  {{.Wrapped}} in Other to control placement in the error message.
-//	  The constructor always takes wrapped error as its first parameter.
-//	  Generates: XxxTemplData (Wrapped as string), XxxError (Wrapped as
-//	             error), NewXxxError(wrapped error, fields...),
-//	             AsXxxError helper, Error() string, Unwrap() error.
-//
-// # Validation
+// # UnderlyingType validation rules
 //
 // lingo validates the entire Underliers map before generating any files.
 // Generation only proceeds when zero errors are found. Detected errors:
@@ -93,12 +34,22 @@ const (
 
 	// UnderlyingTypeDynamicCobra is a dynamic Cobra command/flag
 	// description with variable content.
+	// Every {{.Token}} in Other must have a matching Fields entry and
+	// vice versa.
+	// Fields must be non-empty.
+	// Generates:
+	// - NewXxxTemplData constructor generated.
 	UnderlyingTypeDynamicCobra // DynamicCobra
 
 	// UnderlyingTypeStaticGeneral is a static non-error user-facing message.
 	UnderlyingTypeStaticGeneral // StaticGeneral
 
 	// UnderlyingTypeDynamicGeneral is a dynamic non-error user-facing message.
+	// Every {{.Token}} in Other must have a matching Fields entry and
+	// vice versa.
+	// Fields must be non-empty.
+	// Generates:
+	// - NewXxxTemplData constructor generated.
 	UnderlyingTypeDynamicGeneral // DynamicGeneral
 
 	// UnderlyingTypeStaticError is a static error with no variable content.
@@ -106,6 +57,9 @@ const (
 
 	// UnderlyingTypeSentinelError is a static sentinel error designed to be
 	// wrapped by outer errors.
+	// Generates:
+	// - XxxError
+	// ErrXxx sentinel.
 	UnderlyingTypeSentinelError // SentinelError
 
 	// UnderlyingTypeStaticErrorWrapper is a static error that wraps another
@@ -113,6 +67,8 @@ const (
 	// message text is fully fixed; the wrapped error's text does not appear
 	// in the translated output. Use UnderlyingTypeStaticErrorWrapperMsg when
 	// you want {{.Wrapped}} to appear inside the Other string.
+	// Generates:
+	// - XxxError
 	UnderlyingTypeStaticErrorWrapper // StaticErrorWrapper
 
 	// UnderlyingTypeStaticErrorWrapperMsg is a static error that wraps another
@@ -120,12 +76,24 @@ const (
 	// translated output via {{.Wrapped}} in Other. If the message text is
 	// fully fixed and you only need the wrapped error for the error chain,
 	// use UnderlyingTypeStaticErrorWrapper instead.
+	// Generates:
+	// - NewXxxError(wrapped error)
+	// - Error() string
+	// - Unwrap() error
 	UnderlyingTypeStaticErrorWrapperMsg // StaticErrorWrapperMsg
 
 	// UnderlyingTypeDynamicError is a dynamic error with no wrapping.
+	// Fields must be non-empty. No Wrapped field permitted in Fields.
+	// Generates:
+	// - NewXxxError
 	UnderlyingTypeDynamicError // DynamicError
 
 	// UnderlyingTypeDynamicErrorWrapper is a dynamic error that wraps
 	// another error.
+	// Fields must be non-empty.
+	// Generates:
+	// - NewXxxError(wrapped error)
+	// - Error() string
+	// - Unwrap() error
 	UnderlyingTypeDynamicErrorWrapper // DynamicErrorWrapper
 )


### PR DESCRIPTION
…of Use (#139)

fix(doc): synchronise README with underlying type enum documentation (#139)

ref(translate): introduce Render and Register to improve Use semantics (#139)